### PR TITLE
Let build be a pure function

### DIFF
--- a/lib/screens/contacts_screen.dart
+++ b/lib/screens/contacts_screen.dart
@@ -19,8 +19,14 @@ class ContactsScreen extends StatefulWidget {
 
 class _ContactsScreenState extends State<ContactsScreen> {
   String _subTitle = '';
-  List<Profile> _profiles;
+  Future<List<Profile>> _profiles;
   DatabaseService _database = DatabaseService();
+
+  @override
+  void initState() {
+    super.initState();
+    _profiles = _database.getProfileList();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,27 +49,19 @@ class _ContactsScreenState extends State<ContactsScreen> {
     );
   }
 
-  Future<List<Profile>> getProfiles() async {
-    List<Profile> profiles = await _database.getProfileList();
-    setState(() {
-      _profiles = profiles;
-      _subTitle = '${_profiles.length} contacts';
-    });
-    return profiles;
-  }
 
   Widget showContactList() {
     return FutureBuilder(
-      future: getProfiles(),
+      future: _profiles,
       builder: (context, AsyncSnapshot<List<Profile>> snapshot) {
         if (!snapshot.hasData) {
           return Center(child: CircularProgressIndicator());
         }
-        _profiles = snapshot.data;
+        List<Profile> profiles = snapshot.data;
         return ListView.builder(
-            itemCount: _profiles.length,
+            itemCount: profiles.length,
             itemBuilder: (BuildContext context, int index) {
-              Profile profile = _profiles[index];
+              Profile profile = profiles[index];
 
               return Padding(
                 padding: const EdgeInsets.all(8.0),


### PR DESCRIPTION
The previous version was calling getProfiles() at every build. And when getProfiles was finished, it updated the state, thus triggering a new call to getProfiles(), and so on...

The build function should be pure (i.e not modifying the state in any way) (see https://stackoverflow.com/questions/52021205/usage-of-futurebuilder-with-setstate/52021385#52021385)